### PR TITLE
fix: add contents write permission to enable release creation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 env:
   DOCKER_USERNAME: donepuchie                     # DockerHub username
   REPO: donepuchie/auto-version-ci               # DockerHub repository name (user/repo)


### PR DESCRIPTION
This PR adds the necessary `contents: write` permission to the release workflow to allow the `actions/create-release` step to create GitHub releases successfully.

Without this permission, the workflow fails with a "Resource not accessible by integration" error when attempting to publish a release.

Changes:
- Added `permissions: contents: write` to `.github/workflows/release.yml`

This ensures that the release step has sufficient access when triggered via GitHub Actions.
